### PR TITLE
fix: impossible type annotations on Avg/MaxPool2d

### DIFF
--- a/quill/nn/_avgpool2d.py
+++ b/quill/nn/_avgpool2d.py
@@ -34,8 +34,8 @@ class AvgPool2d(Module):
         for i_stride in range(len(stride)):
             expr_check(stride[i_stride], f"stride[{i_stride}]", lambda x: x > 0)
 
-        self.kernel_size: int | tuple[int, int] = kernel_size
-        self.stride: int | tuple[int, int] | None = stride
+        self.kernel_size: tuple[int, int] = kernel_size
+        self.stride: tuple[int, int] = stride
     
     def forward(self, x: Tensor) -> Tensor:
         return avgpool3d(x, self.kernel_size, self.stride)

--- a/quill/nn/_maxpool2d.py
+++ b/quill/nn/_maxpool2d.py
@@ -34,8 +34,8 @@ class MaxPool2d(Module):
         for i_stride in range(len(stride)):
             expr_check(stride[i_stride], f"stride[{i_stride}]", lambda x: x > 0)
         
-        self.kernel_size: int | tuple[int, int] = kernel_size
-        self.stride: int | tuple[int, int] | None = stride
+        self.kernel_size: tuple[int, int] = kernel_size
+        self.stride: tuple[int, int] = stride
     
     def forward(self, x: Tensor) -> Tensor:
         return maxpool3d(x, self.kernel_size, self.stride)


### PR DESCRIPTION
quill.nn.AvgPool2d
- fix: self.kernel_size and self.stride are now correctly annotated as tuple[int, int] only

quill.nn.MaxPool2d
- fix: self.kernel_size and self.stride are now correctly annotated as tuple[int, int] only