### PR TITLE
fix: default shuffle value for DataLoader

### DIFF
--- a/quill/utils/data/_dataloader.py
+++ b/quill/utils/data/_dataloader.py
@@ -7,7 +7,7 @@ from ...nn.functional import stack
 
 class DataLoader:
 
-    def __init__(self, dataset: Dataset, batch_size: int = 1, shuffle: bool = True) -> None:
+    def __init__(self, dataset: Dataset, batch_size: int = 1, shuffle: bool = False) -> None:
         self.dataset: Dataset = dataset
         self.batch_size: int = batch_size
         self.shuffle: bool = shuffle


### PR DESCRIPTION
quill.utils.data.DataLoader
- fix: default shuffle value is set to False