### PR TITLE
fix: search logic in Optimizer._modify_params

### DIFF
--- a/quill/optim/_optimizer.py
+++ b/quill/optim/_optimizer.py
@@ -14,7 +14,7 @@ class Optimizer:
         values: list[_State] = list(self.params.values())
         visited: list[_State] = []
         while len(values) > 0:
-            v = values.pop(0)
+            v: _State = values.pop(0)
             if v not in visited:
                 if isinstance(v, dict):
                     values.extend(list(v.values()))

--- a/quill/optim/_optimizer.py
+++ b/quill/optim/_optimizer.py
@@ -12,15 +12,15 @@ class Optimizer:
     
     def _modify_params(self, expr: Callable[[Tensor], None]) -> None:
         values: list[_State] = list(self.params.values())
-        visited: set[_State] = set()
+        visited: list[_State] = []
         while len(values) > 0:
             v = values.pop(0)
-            if isinstance(v, dict):
-                if v not in visited:
+            if v not in visited:
+                if isinstance(v, dict):
                     values.extend(list(v.values()))
-            else:
-                expr(v)
-            visited.add(v)
+                else:
+                    expr(v)
+                visited.add(v)
     
     def zero_grad(self) -> None:
         def _zero_grad_and_reset_velocity(x: Tensor) -> None:


### PR DESCRIPTION
quill.optim.Optimizer
- fix: visited is now a list (because set cannot contain dict objects)
- fix: visited membership will still be checked, even though v is a Tensor

Co-Authored-By: Jonathan Richard Sugandhi <64012903+jonathanrichard13@users.noreply.github.com>